### PR TITLE
Make actor type definition useful (#1224)

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -102,6 +102,10 @@ declare class Locator implements ILocator {
   as(locator:string): Locator;
 }
 
+
+declare function actor(customSteps?: {
+  [action: string]: (this: CodeceptJS.I, ...args: any[]) => void
+}): CodeceptJS.{{I}};
 declare function actor(customSteps?: {}): CodeceptJS.{{I}};
 declare function Feature(title: string, opts?: {}): FeatureConfig;
 declare const Scenario: {


### PR DESCRIPTION
* Make actor type definition useful

By adding type annotation to `customSteps`, we get hint, that `this` is actually `CodeceptJS.I` and therefore we can do much more, while having some type checks.

* Make actor type definition useful